### PR TITLE
メディアタブでNSFWのモザイク解除を自動的にできるようにした

### DIFF
--- a/packages/frontend/src/components/MkMedias.vue
+++ b/packages/frontend/src/components/MkMedias.vue
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-only
         </div>
       </MkA>
     </div>
-    <div v-else-if="file.isSensitive && !showingFiles.includes(file.id)" :class="$style.img"
+    <div v-else-if="file.isSensitive && !showingFiles.includes(file.id) && !nsfwNoConfirm" :class="$style.img"
          @click="showingFiles.push(file.id)">
       <ImgWithBlurhash :class="$style.sensitiveImg" :hash="file.blurhash" :src="thumbnail(file)" :title="file.name"
                        :forceBlurhash="true"/>
@@ -51,6 +51,7 @@ function thumbnail(image: Misskey.entities.DriveFile): string {
 
 const props = defineProps<{
 	note: Misskey.entities.Note;
+	nsfwNoConfirm: boolean;
 }>();
 </script>
 

--- a/packages/frontend/src/pages/user/post-gallery.vue
+++ b/packages/frontend/src/pages/user/post-gallery.vue
@@ -5,10 +5,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 	<MkSpacer :contentMax="1100">
+		<MkSwitch v-model="nsfwNoConfirm">NSFWの画像をモザイクなしで表示する</MkSwitch>
 		<div :class="$style.root">
 			<MkPagination v-slot="{items}" :pagination="pagination">
 				<div :class="$style.stream">
-					<MkMedias v-for="note in items" :note="note"/>
+					<MkMedias v-for="note in items" :note="note" :nsfwNoConfirm="nsfwNoConfirm"/>
 				</div>
 			</MkPagination>
 		</div>
@@ -19,12 +20,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 import MkMedias from "@/components/MkMedias.vue";
 import MkPagination from "@/components/MkPagination.vue";
-import {computed} from "vue";
+import {ref, computed} from "vue";
 import * as Misskey from "misskey-js";
+import MkSwitch from "@/components/MkSwitch.vue";
 
 const props = defineProps<{
 	user: Misskey.entities.UserDetailed;
 }>();
+
+const nsfwNoConfirm = ref<boolean>(false);
 
 const pagination = {
 	endpoint: 'users/notes' as const,


### PR DESCRIPTION
自身で投稿した画像などを確認するユースケースに向けて、プロフィールのメディアタブにNSFWを確認なしで表示する機能を追加